### PR TITLE
Atom parser

### DIFF
--- a/src/Parser/parseRssXml.ts
+++ b/src/Parser/parseRssXml.ts
@@ -57,7 +57,7 @@ function parseAtomXml(data: Document): RssItem[] {
 
     for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
-        const id = getTagValue(entry, "id") || '';
+        const id = getTagValue(entry, "id") || "";
         const title = getTagValue(entry, "title");
         const pubDate = getTagValue(entry, "published");
         const image = undefined; // Atom feeds might not have images

--- a/src/Parser/parseRssXml.ts
+++ b/src/Parser/parseRssXml.ts
@@ -6,31 +6,34 @@ import { RssItem } from "../State/RssItem";
  * @returns list of rss items parsed from XML
  */
 export function parseRssXml(xml: string): RssItem[] {
-    // Some feeds use the Atom format these require slightly different parsing logic
-    // TODO: detect if this is an atom feed and switch over the parser
-
     const data = new window.DOMParser().parseFromString(xml, "text/xml");
+    const feedType = data.getElementsByTagName("feed")[0] ? "atom" : "rss";
 
+    if (feedType === "atom") {
+        return parseAtomXml(data);
+    } else {
+        return parseRssItems(data);
+    }
+}
+
+function getTagValue(item: Element, tagName: string): string | undefined {
+    const tag = item.getElementsByTagName(tagName)[0];
+    const value = tag?.textContent || undefined;
+    return value;
+}
+
+function parseRssItems(data: Document): RssItem[] {
     const items = data.getElementsByTagName("item");
     const rssItems: RssItem[] = [];
+
     for (let i = 0; i < items.length; i++) {
         const item = items[i];
-
-        function getTagValue(item: Element, tagName: string): string | undefined {
-            const tag = item.getElementsByTagName(tagName)[0];
-            const value = tag.textContent || undefined;
-            return value;
-        }
-
-        // Parse individual items values
         const guid = getTagValue(item, "guid");
         const title = getTagValue(item, "title");
         const pubDate = getTagValue(item, "pubDate");
         const image = item.getElementsByTagName("img")[0]?.getAttribute("src") || undefined;
-        const description = item.getElementsByTagName("description")[0].textContent || undefined;
+        const description = getTagValue(item, "description");
         const link = getTagValue(item, "link");
-
-        // Way to uniquely identify the item in the feed - ideally preserved across loads
         const id = guid || title || link || pubDate || "guid";
 
         const rssItem: RssItem = {
@@ -41,7 +44,37 @@ export function parseRssXml(xml: string): RssItem[] {
             description,
             link,
         };
+
         rssItems.push(rssItem);
     }
+
+    return rssItems;
+}
+
+function parseAtomXml(data: Document): RssItem[] {
+    const entries = data.getElementsByTagName("entry");
+    const rssItems: RssItem[] = [];
+
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
+        const id = getTagValue(entry, "id") || '';
+        const title = getTagValue(entry, "title");
+        const pubDate = getTagValue(entry, "published");
+        const image = undefined; // Atom feeds might not have images
+        const description = getTagValue(entry, "content");
+        const link = getTagValue(entry, "link");
+
+        const rssItem: RssItem = {
+            id,
+            title,
+            pubDate,
+            image,
+            description,
+            link,
+        };
+
+        rssItems.push(rssItem);
+    }
+
     return rssItems;
 }

--- a/src/Parser/parseRssXml.ts
+++ b/src/Parser/parseRssXml.ts
@@ -61,8 +61,8 @@ function parseAtomXml(data: Document): RssItem[] {
         const title = getTagValue(entry, "title");
         const pubDate = getTagValue(entry, "published");
         const image = undefined; // Atom feeds might not have images
-        const description = getTagValue(entry, "content");
-        const link = getTagValue(entry, "link");
+        const description = getFirstSentence(getTagValue(entry, "content"));
+        const link = entry.getElementsByTagName("link")[0]?.getAttribute("href") || "";
 
         const rssItem: RssItem = {
             id,
@@ -77,4 +77,12 @@ function parseAtomXml(data: Document): RssItem[] {
     }
 
     return rssItems;
+}
+
+function getFirstSentence(text: string | undefined): string | undefined {
+    if (text) {
+        const sentences = text.split(/[.!?]/);
+        return sentences[0].trim();
+    }
+    return undefined;
 }

--- a/src/registerButtonAddFeed.ts
+++ b/src/registerButtonAddFeed.ts
@@ -5,14 +5,14 @@ import { loadRssUrls } from "./loadRssUrls";
 
 // Add multiple feeds
 const rssUrls = [
-    //"https://feeds.npr.org/1001/rss.xml",
+    "https://feeds.npr.org/1001/rss.xml",
     "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-    //"https://feeds.foxnews.com/foxnews/latest",
-    //"https://www.cbsnews.com/latest/rss/main",
-    //"https://feeds.arstechnica.com/arstechnica/index",
+    "https://feeds.foxnews.com/foxnews/latest",
+    "https://www.cbsnews.com/latest/rss/main",
+    "https://feeds.arstechnica.com/arstechnica/index",
     "https://wandyezj.github.io/feed",
-    //"https://xkcd.com/rss.xml",
-    //"https://techcrunch.com/feed/",
+    "https://xkcd.com/rss.xml",
+    "https://techcrunch.com/feed/",
 
     // URL is configured to rely on same origin policy...
     //"http://rss.cnn.com/rss/cnn_topstories.rss",


### PR DESCRIPTION
forgot npm run style, modified parseRssXml to parse atom feeds (only used Joe's blog as an example)(https://github.com/wandyezj/rss-reader/pull/16)